### PR TITLE
Remove "paused" from required state attributes

### DIFF
--- a/state.schema
+++ b/state.schema
@@ -565,7 +565,6 @@
         "nodeStates",
         "edgeStates",
         "driving",
-        "paused",
         "actionStates",
         "batteryState",
         "operatingMode",


### PR DESCRIPTION
According to section 6.10.6, this attribute is optional, but the current schema enforces its presence.